### PR TITLE
List of changes:

### DIFF
--- a/ezdb.class.php
+++ b/ezdb.class.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Copyright (c) 2010 Nabeel Shahzad
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
 
@@ -24,7 +24,7 @@
  * @copyright Copyright (c) 2008-2010, Nabeel Shahzad
  * @link http://github.com/nshahzad/ezdb
  * @license MIT License
- * 
+ *
  * Based on ezSQL by Justin Vincent: http://justinvincent.com/docs/ezsql/ez_sql_help.htm
  */
 
@@ -42,34 +42,34 @@ class DB
 	public static $rows_affected;
 	public static $connected = false;
 	public static $last_query;
-	
+
 	public static $throw_exceptions = true;
 	public static $default_type = OBJECT;
 	public static $show_errors = false;
 	public static $log_errors = false;
 	public static $error_handler = null;
-	
+
 	public static $table_prefix = '';
 
 	protected static $dbuser;
 	protected static $dbpass;
 	protected static $dbname;
 	protected static $dbserver;
-	
+
 	/**
 	 * Private contructor, don't allow for
 	 * initialization of this class
 	 */
-	private function __contruct()
+	private function __construct()
 	{
 		return;
 	}
-	
+
 	public function __destruct()
 	{
 		@self::$DB->close();
 	}
-	
+
 	/**
 	 * Return the singleton instance of the DB class
 	 *
@@ -79,56 +79,56 @@ class DB
 	{
 		return self::$DB;
 	}
-		
+
 	/**
 	 * Initialize the database connection
 	 *
 	 * @param string $type Either mysql, mysqli, oracle. Default is mysql
 	 * @return boolean
 	 */
-	public static function init($type='mysql')
+	public static function init($type='mysqli')
 	{
 		$class_name = strtolower('ezdb_'.$type);
 		include dirname(__FILE__).DIRECTORY_SEPARATOR.$class_name.'.class.php';
-		
+
 		if(!self::$DB = new $class_name())
 		{
 			self::$error = self::$DB->error;
 			self::$errno = self::$DB->errno;
-			
+
 			return false;
 		}
-		
+
 		return true;
 	}
-	
+
 	public static function set_log_errors($bool)
 	{
 		self::$log_errors = $bool;
 	}
-	
+
 	public static function set_throw_exceptions($bool)
 	{
 		self::$throw_exceptions = $bool;
 	}
-		
+
 	/**
-	 * Set a function/class as an error handler. Function is the 
-	 * same parameter sent to 
-	 * 
+	 * Set a function/class as an error handler. Function is the
+	 * same parameter sent to
+	 *
 	 * http://us.php.net/manual/en/function.call-user-func-array.php
-	 * 
+	 *
 	 * @param $handler method name or class to call on an error
-	 * 
+	 *
 	 */
 	public static function set_error_handler($function)
 	{
-		self::$error_handler = $function;		
+		self::$error_handler = $function;
 	}
-		
+
 	/**
 	 * Enable or disable caching, can be set per-query
-	 * 
+	 *
 	 * @param bool $bool True/False
 	 * @return none
 	 */
@@ -136,51 +136,51 @@ class DB
 	{
 		self::$DB->set_caching($bool);
 	}
-	
+
 	/**
 	 * Set the cache type (file, memcache)
 	 *
 	 * @param string $type Caching type
-	 * @return none 
+	 * @return none
 	 *
 	 */
 	public static function cache_type($type)
 	{
 		self::$DB->cache_type($type);
 	}
-	
+
 	/**
 	 * Set the path of the cache
 	 *
 	 * @param mixed $path This is a description
 	 * @return mixed This is the return value description
 	 *
-	 */	
+	 */
 	public static function set_cache_dir($path)
 	{
 		self::$DB->set_cache_dir($path);
 	}
-	
-		
+
+
 	/* Aliases for above, backwards compat */
-	
+
 	public static function setCacheDir($path)
 	{
 		self::set_cache_dir($path);
 	}
-	
+
 	public static function enableCache()
 	{
 		self::$DB->set_caching(true);
 	}
-	
+
 	public static function disableCache()
 	{
 		self::$DB->set_caching(false);
 	}
-	
+
 	/* End aliases */
-	
+
 	/**
 	 * Connect to database
 	 *
@@ -190,47 +190,39 @@ class DB
 	 * @param string $server
 	 * @return boolean
 	 */
-	public static function connect($user='', $pass='', $name='', $server='')
+	public static function connect($user='', $pass='', $name='', $server='', $char_set='utf8')
 	{
-		if(!self::$DB->connect($user, $pass, $server))
+		if(!self::$DB->connect($user, $pass, $server, $char_set))
 		{
 			self::$error = self::$DB->error;
 			self::$errno = self::$DB->errno;
-			
+
 			return false;
 		}
-		
+
 		if(!self::$DB->select($name))
 		{
 			self::$error = self::$DB->error;
 			self::$errno = self::$DB->errno;
-			
+
 			return false;
 		}
-		
+
 		self::$dbuser = $user;
 		self::$dbpass = $pass;
 		self::$dbname = $name;
 		self::$dbserver = $server;
-		
+
 		self::$DB->dbuser = $user;
 		self::$DB->dbpassword = $pass;
 		self::$DB->dbname = $name;
 		self::$DB->dbhost = $server;
-		
+
 		self::$DB->throw_exceptions = self::$throw_exceptions;
 		self::$connected = true;
 		return true;
 	}
 
-	public static function num_queries()
-	{
-		
-		return self::$DB->num_queries();
-
-	}
-
-	
 	/**
 	 * Select/Change the active database. It's called from
 	 * connect(), but can also be changed
@@ -241,17 +233,17 @@ class DB
 	public static function select($dbname)
 	{
 		self::$DB->throw_exceptions = self::$throw_exceptions;
-		
+
 		$ret = self::$DB->select($dbname);
 		self::$error = self::$DB->error;
 		self::$errno = self::$DB->errno;
-		
+
 		if(self::$errno == 0)
 			return true;
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Close the database connector
 	 *
@@ -261,7 +253,7 @@ class DB
 	{
 		return @self::$DB->close();
 	}
-	
+
 	/**
 	 * Set a table prefix for the quick_ functions
 	 * If it's set to blank (default), then no prefix will be used
@@ -272,7 +264,7 @@ class DB
 	{
 		self::$table_prefix = '';
 	}
-	
+
 	/**
 	 * Do a "quick select".
 	 * @see http://www.nsslive.net/codon/docs/database#quick_functions
@@ -288,7 +280,7 @@ class DB
 		self::$DB->throw_exceptions = self::$throw_exceptions;
 		return self::$DB->quick_select($table, $fields, $cond);
 	}
-	
+
 	/**
 	 * Do a quick insert into a table
 	 * @see http://www.nsslive.net/codon/docs/database#quick_functions
@@ -303,7 +295,7 @@ class DB
 		self::$DB->throw_exceptions = self::$throw_exceptions;
 		return self::$DB->quick_insert($table, $fields, $flags, $allowed_cols);
 	}
-	
+
 	/**
 	 * Do a "quick update"
 	 * @see http://www.nsslive.net/codon/docs/database#quick_functions
@@ -318,7 +310,7 @@ class DB
 		self::$DB->throw_exceptions = self::$throw_exceptions;
 		return self::$DB->quick_update($table, $fields, $cond, $allowed_cols);
 	}
-	
+
 	/**
 	 * Build a SELECT statement
 	 *
@@ -327,7 +319,7 @@ class DB
 	{
 		return self::$DB->build_select($params);
 	}
-	
+
 	/**
 	 * Build a WHERE clause for an SQL statement with supplied parameters
 	 *
@@ -339,8 +331,8 @@ class DB
 	{
 		return self::$DB->build_where($fields);
 	}
-	
-	
+
+
 	/**
 	 * Build the update clause (after the SET and before WHERE)
 	 *
@@ -352,7 +344,7 @@ class DB
 	{
 		return self::$DB->build_update($fields);
 	}
-	
+
 	/**
 	 * Write out the last query to a debug log, or error
 	 *
@@ -365,9 +357,9 @@ class DB
 		{
 			return;
 		}
-		
+
 		$backtrace = debug_backtrace();
-			
+
 		$debug_info = array(
 			'backtrace' => $backtrace,
 			'sql' => self::$last_query,
@@ -378,10 +370,10 @@ class DB
 			'dbpass' => self::$dbpass,
 			'dbserver' => self::$dbserver,
 		);
-			
+
 		call_user_func_array(self::$error_handler, array($debug_info));
 	}
-	
+
 	/**
 	 * Return array of results. Default returns array of
 	 * objects. Can be ARRAY_A, ARRAY_N or OBJECT, for
@@ -395,25 +387,25 @@ class DB
 	public static function get_results($query, $type='')
 	{
 		if($type == '') $type = self::$default_type;
-		
+
 		self::$DB->throw_exceptions = self::$throw_exceptions;
-		
+
 		$ret = self::$DB->get_results($query, $type);
-		
+
 		self::$error = self::$DB->error;
 		self::$errno = self::$DB->errno;
 		self::$num_rows = self::$DB->num_rows;
 		self::$last_query = $query;
-		
+
 		// Log any erronious queries
 		if(self::$DB->errno != 0)
 		{
 			self::write_debug();
 		}
-		
+
 		return $ret;
 	}
-	
+
 	/**
 	 * Return a single row
 	 *
@@ -425,24 +417,24 @@ class DB
 	public static function get_row($query, $type='', $y=0)
 	{
 		if($type == '') $type = self::$default_type;
-		
+
 		self::$DB->throw_exceptions = self::$throw_exceptions;
-		
+
 		$ret = self::$DB->get_row($query, $type, $y);
-		
+
 		self::$error = self::$DB->error;
 		self::$errno = self::$DB->errno;
 		self::$last_query = $query;
-		
+
 		// Log any erronious queries
 		if(self::$DB->errno != 0)
 		{
 			self::write_debug();
 		}
-		
+
 		return $ret;
 	}
-	
+
 	/**
 	 * Perform a query
 	 *
@@ -452,32 +444,32 @@ class DB
 	public static function query($query)
 	{
 		self::$DB->throw_exceptions = self::$throw_exceptions;
-		
+
 		$ret = self::$DB->query($query);
-		
+
 		self::$error = self::$DB->error;
 		self::$errno = self::$DB->errno;
 		self::$rows_affected = self::$num_rows = self::$DB->num_rows;
 		self::$insert_id = self::$DB->insert_id;
 		self::$last_query = $query;
-		
+
 		// Log any erronious queries
 		if(self::$DB->errno != 0)
 		{
 			self::write_debug();
 		}
-		
+
 		return $ret; //self::$insert_id;
 	}
 
-	/** 
+	/**
 	 * Return all of the columns
 	 */
 	public static function get_cols()
 	{
 		return self::$DB->get_cols();
 	}
-	
+
 	/**
 	 * Get information about a column
 	 *
@@ -489,7 +481,7 @@ class DB
 	{
 		return self::$DB->get_col_info($info_type, $col_offset);
 	}
-	
+
 	/**
 	 * Return a single value from a query
 	 *
@@ -501,37 +493,47 @@ class DB
 	{
 		return self::$DB->get_col($query, $offset);
 	}
-		
+
+	/**
+	 * Return the ID generated in the last query.
+	 *
+	 * @return unknown
+	 */
+	public static function get_insert_id()
+	{
+		return self::$DB->get_insert_id();
+	}
+
 	public static function get_var($query=null, $x=0, $y=0)
 	{
 		return self::$DB->get_var($query, $x, $y);
 	}
-	
+
 	public static function num_rows()
 	{
 		return self::$num_rows;
 	}
-	
+
 	public static function vardump($mixed='')
 	{
 		return self::$DB->vardump($mixed);
 	}
-	
+
 	public static function dumpvar($mixed='')
 	{
 		return self::$DB->vardump($mixed);
 	}
-	
+
 	public static function get_cache($query)
 	{
 		return self::$DB->get_cache($query);
 	}
-	
+
 	public static function store_cache($query, $is_insert)
 	{
 		return self::$DB->store_cache($query, $is_insert);
 	}
-	
+
 	/**
 	 * Get the error string from the last query
 	 *
@@ -551,7 +553,7 @@ class DB
 	{
 		return self::$DB->errno();
 	}
-	
+
 	/**
 	 * Return array of all the errors
 	 *
@@ -561,7 +563,7 @@ class DB
 	{
 		return self::$DB->get_all_errors();
 	}
-	
+
 	public static function flush()
 	{
 		return self::$DB->flush();
@@ -570,17 +572,17 @@ class DB
 	{
 		return self::$DB->show_errors();
 	}
-	
+
 	public static function hide_errors()
 	{
 		return self::$DB->hide_errors();
 	}
-	
+
 	public static function escape($val)
 	{
 		return self::$DB->escape($val);
 	}
-	
+
 	public static function debug($return = false)
 	{
 		if(self::$show_errors === true)

--- a/ezdb_base.class.php
+++ b/ezdb_base.class.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Copyright (c) 2010 Nabeel Shahzad
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
 
@@ -24,22 +24,22 @@
  * @copyright Copyright (c) 2008-2010, Nabeel Shahzad
  * @link http://github.com/nshahzad/ezdb
  * @license MIT License
- * 
- * 
+ *
+ *
  * Based on ezSQL by Justin Vincent: http://justinvincent.com/docs/ezsql/ez_sql_help.htm
  */
 
 /**********************************************************************
-* 
-*  Name..: ezDB
-*  Desc..: ezDB Core module - database abstraction library to make
-*          it very easy to deal with databases.
-*
-*/
+ *
+ *  Name..: ezDB
+ *  Desc..: ezDB Core module - database abstraction library to make
+ *          it very easy to deal with databases.
+ *
+ */
 
 /**********************************************************************
-*  ezDB Constants
-*/
+ *  ezDB Constants
+ */
 
 define('ezDB_VERSION','3.00');
 define('OBJECT','OBJECT', true);
@@ -50,13 +50,13 @@ define('ARRAY_N','ARRAY_N', true);
  *  Simple exception container class
  *
  */
-class ezDB_Error extends Exception 
+class ezDB_Error extends Exception
 {
 	/* Use these to keep it consistant with ezDB_Base */
 	public $error;
 	public $errno;
 	public $last_query = '';
-	
+
 	public function __construct($message, $code, $query='')
 	{
 		parent::__construct($message, $code);
@@ -64,15 +64,15 @@ class ezDB_Error extends Exception
 		$this->error = $message;
 		$this->errno = $code;
 	}
-	
+
 	public function __toString()
 	{
-		$html .= '<blockquote>';
+		$html = '<blockquote>';
 		$html .= '<font face=arial size=2 color=000099><b>Last Error --</b> [<font color=000000><b>'.
-						$this->message . ' (' . $this->code . ')</b></font>]<br />';		
+			$this->error . ' (' . $this->errno . ')</b></font>]<br />';
 		$html .= '[<font color=000000><b>'.$this->last_query.'</b></font>]</font><p>
-					</blockquote><hr noshade color=dddddd size=1>';
-			
+			</blockquote><hr noshade color=dddddd size=1>';
+
 		return $html;
 	}
 }
@@ -84,54 +84,57 @@ class ezDB_Error extends Exception
  */
 class ezDB_Base
 {
-	
-	public $trace            = false;  // same as $debug_all
-	public $debug_all        = false;  // same as $trace
-	public $debug_called     = false;
-	public $vardump_called   = false;
-	public $show_errors      = true;
-	public $num_queries      = 0;
-	public $last_query       = null;
-	public $error		      = null;
-	public $errno			  = null;
-	public $col_info         = null;
-	public $captured_errors  = array();
+
+	public $trace				= false;  // same as $debug_all
+	public $debug_all			= false;  // same as $trace
+	public $debug_called		= false;
+	public $vardump_called		= false;
+	public $show_errors			= true;
+	public $num_queries			= 0;
+	public $last_query			= null;
+	public $error				= null;
+	public $errno				= null;
+	public $col_info			= null;
+	public $captured_errors		= array();
 	public $insert_id;
-	
-	public $table_prefix = '';
-	
-	protected $dbuser = false;
-	protected $dbpassword = false;
-	protected $dbname = false;
-	protected $dbhost = false;
+
+	public $table_prefix		= '';
+
+	protected $dbuser			= false;
+	protected $dbpassword		= false;
+	protected $dbname			= false;
+	protected $dbhost			= false;
 	public $result;
-	
-	public $default_type = OBJECT;
-	public $get_col_info = false;
-	
+
+	public $default_type		= OBJECT;
+	public $get_col_info		= false;
+
 	public $debug_echo_is_on = true;
 	public $throw_exceptions = true;
-	
+
 	/* These settings are handled by __set() below, but can still
 		be called as $db->cache_type = '...';, just under-go some
 		checking to make sure that they're valid */
 	protected $settings = array(
-		'cache_type'	=> 'file',
-		);
-		
-	public $cache_timeout	= 3600;		# In seconds
-	public $cache_dir       = false;	# Directory to cache to if using 'file'
-	public $cache_queries   = false;
-	public $cache_inserts   = false;
-	public $use_disk_cache  = false;
-	
-	protected $last_result;	
-	
+		'cache_type' => 'file',
+	);
+
+	public $cache_timeout		= 3600;		# In seconds
+	public $cache_dir			= false;	# Directory to cache to if using 'file'
+	public $cache_query			= false;
+	public $cache_inserts		= false;
+	public $use_disk_cache		= false;
+
+	protected $last_result;
+
+	# MySQL Server Version.
+	public $server_version;
+
 	public function __construct()
 	{
 		# Check for memcache support
 	}
-	
+
 	public function __set($name, $value)
 	{
 		switch($name)
@@ -139,14 +142,13 @@ class ezDB_Base
 			case 'cache_type':
 				$this->set_cache_type($value);
 				break;
-				
+
 			default:
 				$this->settings[$name] = $value;
 				break;
 		}
-		
 	}
-	
+
 	public function __get($name)
 	{
 		if(!isset($this->settings[$name]))
@@ -154,10 +156,10 @@ class ezDB_Base
 			$this->settings[$name] = null;
 			return null;
 		}
-		
+
 		return $this->settings[$name];
 	}
-	
+
 	/**
 	 * Clear any previous errors
 	 */
@@ -165,43 +167,40 @@ class ezDB_Base
 	{
 		$this->error = '';
 		$this->errno = 0;
-	}	
-	
-	
+	}
+
 	/**
 	 * Set a table prefix for quick_*() functions
 	 *
 	 * @param string $prefix Table prefix
-	 * @return none 
+	 * @return none
 	 *
 	 */
 	public function set_table_prefix($prefix='')
 	{
 		$this->table_prefix = $prefix;
 	}
-	
-	
+
 	/**
 	 * Set the option to throw exceptions or not
 	 *
 	 * @param bool $bool True or false
-	 * @return none 
+	 * @return none
 	 *
 	 */
 	public function throw_exceptions($bool=true)
 	{
 		$this->throw_exceptions = $bool;
 	}
-	
+
 	/**
 	 * Enable or disable caching, can be set per-query
-	 * 
+	 *
 	 * @param bool $bool True/False
 	 * @return none
 	 */
 	public function set_caching($bool)
 	{
-		
 		if($bool === true)
 		{
 			$this->cache_query = true;
@@ -210,15 +209,15 @@ class ezDB_Base
 		else
 		{
 			$this->cache_query = false;
-			$this->use_disk_cache = false;			
+			$this->use_disk_cache = false;
 		}
 	}
-	
+
 	/**
 	 * Set the cache type (file, memcache, check)
 	 *
 	 * @param string $type Caching type
-	 * @return none 
+	 * @return none
 	 *
 	 */
 	public function set_cache_type($type)
@@ -226,10 +225,10 @@ class ezDB_Base
 		if($type == 'memcache')
 		{
 			$this->settings['cache_type'] = 'file'; # Not enabled for now
-			
+
 			if($this->throw_exceptions)
 				throw new ezDB_Error('memcache not available', -1);
-				
+
 			return false;
 		}
 		elseif($type == 'apc')
@@ -237,10 +236,10 @@ class ezDB_Base
 			if(!function_exists('apc_add'))
 			{
 				$this->settings['cache_type'] = 'file';
-				
+
 				if($this->throw_exceptions)
 					throw new ezDB_Error('apc not available', -1);
-					
+
 				return false;
 			}
 		}
@@ -249,11 +248,10 @@ class ezDB_Base
 			# Default to file if they selected anythign weird
 			$this->settings['cache_type'] = 'file';
 		}
-		
+
 		return true;
 	}
-	
-	
+
 	/**
 	 * Set the path of the cache
 	 *
@@ -265,13 +263,12 @@ class ezDB_Base
 	{
 		$this->cache_dir = $path;
 	}
-	
+
 	public function set_cache_timeout($timeout)
 	{
 		$this->cache_timeout= $timeout;
 	}
-	
-	
+
 	/**
 	 * Save an error that occurs in our log
 	 *
@@ -285,18 +282,17 @@ class ezDB_Base
 		// Keep track of last error
 		$this->error = $err_str;
 		$this->errno = $err_no;
-	
+
 		// Capture all errors to an error array no matter what happens
 		$this->captured_errors[] = array(
-							'error' => $err_str,
-							'errno' => $err_no,
-							'query' => $this->last_query);
-			
+			'error' => $err_str,
+			'errno' => $err_no,
+			'query' => $this->last_query);
+
 		//show output if enabled
 		//$this->show_errors ? trigger_error($this->error . '(' . $this->last_query . ')', E_USER_WARNING) : null;
 	}
-	
-	
+
 	/**
 	 * Get the error log from all the query
 	 *
@@ -307,8 +303,7 @@ class ezDB_Base
 	{
 		return $this->captured_errors;
 	}
-	
-		
+
 	/**
 	 * Returns the error string from the previous query
 	 *
@@ -319,8 +314,7 @@ class ezDB_Base
 	{
 		return $this->error;
 	}
-	
-	
+
 	/**
 	 * Returns the error code from the previous query
 	 *
@@ -331,7 +325,7 @@ class ezDB_Base
 	{
 		return $this->errno;
 	}
-	
+
 	/**
 	 * Show all errors by default
 	 *
@@ -343,8 +337,7 @@ class ezDB_Base
 		$this->show_errors = true;
 		return true;
 	}
-	
-	
+
 	/**
 	 * Hide any errors from showing by default.
 	 * Can also access the property as $this->show_errors=false
@@ -357,7 +350,7 @@ class ezDB_Base
 		$this->show_errors = false;
 		return true;
 	}
-	
+
 	/**
 	 * Remove the results from the last query
 	 *
@@ -371,16 +364,10 @@ class ezDB_Base
 		$this->col_info = null;
 		$this->last_query = null;
 		$this->from_disk_cache = false;
-		
+
 		return true;
 	}
 
-
-	public function num_queries()
-	{
-		return $this->num_queries;
-	}
-			
 	/**
 	 * Get a single column/variable
 	 *
@@ -392,27 +379,25 @@ class ezDB_Base
 	 */
 	public function get_var($query=null,$x=0,$y=0)
 	{
-		
 		// Log how the function was called
 		$this->func_call = "\$db->get_var(\"$query\",$x,$y)";
-		
+
 		// If there is a query then perform it if not then use cached results..
 		if ( $query )
 		{
 			$this->query($query);
 		}
-		
+
 		// Extract var out of cached results based x,y vals
 		if ( $this->last_result[$y] )
 		{
 			$values = array_values(get_object_vars($this->last_result[$y]));
 		}
-		
+
 		// If there is a value return it else return null
 		return (isset($values[$x]) && $values[$x]!=='')?$values[$x]:null;
 	}
-	
-		
+
 	/**
 	 * Return one row from the DB query (use if your doing LIMIT 1)
 	 *	or are expecting/want only one row returned
@@ -426,16 +411,16 @@ class ezDB_Base
 	public function get_row($query=null,$output='',$y=0)
 	{
 		if($output == '') $output = $this->default_type;
-		
+
 		// Log how the function was called
 		$this->func_call = "\$db->get_row(\"$query\",$output,$y)";
-		
+
 		// If there is a query then perform it if not then use cached results..
 		if ( $query )
 		{
 			$this->query($query);
 		}
-		
+
 		// If the output is an object then return object using the row offset..
 		if ( $output == OBJECT )
 		{
@@ -456,10 +441,8 @@ class ezDB_Base
 		{
 			$this->print_error(" \$db->get_row(string query, output type, int offset) -- Output type must be one of: OBJECT, ARRAY_A, ARRAY_N");
 		}
-		
 	}
-	
-	
+
 	/**
 	 * Quote a value properly, check if its a function first though
 	 * For instance, passing NOW() will just return NOW. Just a simple
@@ -475,15 +458,14 @@ class ezDB_Base
 		{
 			return $value;
 		}
-		
+
 		return '\''.$value.'\'';
-	}	
-	
-	
+	}
+
 	/**
 	 * Build a SELECT SQL Query. All values except for
 	 *  numeric and NOW() will be put in quotes
-	 * 
+	 *
 	 * Values are NOT escaped
 	 *
 	 * @param string $table Table to build update on
@@ -502,20 +484,19 @@ class ezDB_Base
 		{
 			$fields = implode(',', $fields);
 		}
-		
+
 		$sql .= $fields;
 		$sql .= ' FROM '.$table;
 
 		$sql .= $this->build_where($cond);
-		
+
 		return	$this->get_results($sql);
 	}
-	
-	
+
 	/**
 	 * Build a quick INSERT query. For simplistic INSERTs only,
 	 *  all values except numeric and NOW() are put in quotes
-	 * 
+	 *
 	 * Values are NOT escaped
 	 *
 	 * @param string $table Table to insert into
@@ -527,9 +508,9 @@ class ezDB_Base
 	public function quick_insert($table, $fields, $flags= '', $allowed_cols='')
 	{
 		if($table ==  '') return false;
-		
+
 		$sql = 'INSERT '. $flags .' INTO '.$table.' ';
-		
+
 		$cols = array();
 		$col_values = array();
 
@@ -562,17 +543,16 @@ class ezDB_Base
 				}
 			}
 		}
-				
+
 		$sql .= '('.implode(', ', $cols).') VALUES ('.implode(', ', $col_values).')';
-			
+
 		return $this->query($sql);
 	}
-	
-	
+
 	/**
 	 * Build a UPDATE SQL Query. All values except for
 	 *  numeric and NOW() will be put in quotes
-	 * 
+	 *
 	 * Values are NOT escaped
 	 *
 	 * @param string $table Table to build update on
@@ -584,9 +564,9 @@ class ezDB_Base
 	public function quick_update($table, $fields, $cond='', $allowed_cols='')
 	{
 		if($table ==  '') return false;
-		
+
 		$sql = 'UPDATE '.$table.' SET ';
-		
+
 		/* If they passed an associative array of col=>value */
 		if(is_array($fields))
 		{
@@ -611,9 +591,9 @@ class ezDB_Base
 		{
 			$sql .= $fields;
 		}
-		
+
 		$sql .= $this->build_where($cond);
-		
+
 		return $this->query($sql);
 	}
 
@@ -621,7 +601,7 @@ class ezDB_Base
 	 * Build a SELECT query, specifying the table, fields and extra conditions
 	 *
 	 * @param array $data
-	 * 
+	 *
 	 * $data = array(
 	 *		'table' => 'Tablename',
 	 *		'fields' => array(fields),
@@ -629,7 +609,7 @@ class ezDB_Base
 	 *		'order' => 'field ASC',
 	 *		'group' => 'field',
 	 * );
-	 * 
+	 *
 	 * @return type Array of results
 	 *
 	 */
@@ -637,9 +617,9 @@ class ezDB_Base
 	{
 		if(!is_array($params)) return;
 		if($params['table'] == '') return false;
-					
+
 		$sql = 'SELECT ';
-		
+
 		if(is_array($params['fields']))
 		{
 			$sql .= implode(',', $params['fields']);
@@ -648,32 +628,32 @@ class ezDB_Base
 		{
 			$sql .= $params['fields'];
 		}
-		
+
 		$sql .= ' FROM '.$params['table'];
-		
+
 		if(!empty($params['where']))
 		{
 			$sql .= $this->build_where($params['where']);
 		}
-			
+
 		if(!empty($params['group']))
 		{
 			$sql .= ' GROUP BY '.$params['group'];
 		}
-		
+
 		if(!empty($params['order']))
 		{
 			$sql .= ' ORDER BY '.$params['order'];
 		}
-		
+
 		if(!empty($params['limit']))
 		{
 			$sql .= ' LIMIT '.$params['limit'];
 		}
-		
+
 		return $sql;
 	}
-	
+
 	public function build_where($fields)
 	{
 		if(count($fields) === 0 || empty($fields) === true)
@@ -687,7 +667,7 @@ class ezDB_Base
 			$fields = str_ireplace('WHERE', '', $fields);
 			return ' WHERE '.$fields;
 		}
-		
+
 		// Cast it to an array...
 		if(is_object($fields))
 		{
@@ -695,7 +675,7 @@ class ezDB_Base
 		}
 
 		$sql = ' WHERE ';
-		
+
 		$where_clauses = array();
 		foreach($fields as $column_name => $value)
 		{
@@ -703,14 +683,14 @@ class ezDB_Base
 			if(is_array($value))
 			{
 				$sql_temp = "{$column_name} IN (";
-				
+
 				$value_list = array();
 				foreach($value as $in)
 				{
 					$in = $this->escape($in);
 					$value_list[] = "'{$in}'";
 				}
-				
+
 				$sql_temp .= implode(',', $value_list).")";
 				$where_clauses[] = $sql_temp;
 			}
@@ -722,7 +702,7 @@ class ezDB_Base
 					$where_clauses[] = $value;
 					continue;
 				}
-				
+
 				# If there's a % (wildcard) in there, so it should use a LIKE
 				if(substr_count($value, '%') > 0)
 				{
@@ -730,35 +710,35 @@ class ezDB_Base
 					$where_clauses[] = "{$column_name} LIKE '{$value}'";
 					continue;
 				}
-				
+
 				# If it's a greater than or equal to, or for some reason an equals
 				if($value[0] == '<' || $value[0] == '>' || $value[0] == '=')
 				{
 					$where_clauses[] = "{$column_name} {$value}";
 					continue;
 				}
-				
+
 				$value = $this->escape($value);
 				$where_clauses[] = "{$column_name} = '{$value}'";
 			}
 		}
-			
+
 		$sql.= implode(' AND ', $where_clauses).' ';
 		unset($where_clauses);
-		
-		return $sql;		
+
+		return $sql;
 	}
-	
+
 	public function build_update($fields)
 	{
 		if(!is_array($fields))
 		{
 			return $fields;
 		}
-		
+
 		$sql = '';
 		$sql_cols = array();
-		
+
 		foreach($fields as $col => $value)
 		{
 			/* If there's a value just added */
@@ -767,9 +747,9 @@ class ezDB_Base
 				$sql_cols[] = $value;
 				continue;
 			}
-			
+
 			$tmp = "`{$col}`=";
-			
+
 			if(is_int($value))
 			{
 				$tmp .= $value;
@@ -786,16 +766,16 @@ class ezDB_Base
 					$tmp.="'{$value}'";
 				}
 			}
-			
+
 			$sql_cols[] = $tmp;
 		}
-		
+
 		$sql .= implode(', ', $sql_cols);
 		unset($sql_cols);
-		
+
 		return $sql;
 	}
-		
+
 	/**
 	 * Get the value of one column from a query
 	 *
@@ -806,22 +786,21 @@ class ezDB_Base
 	 */
 	public function get_col($query=null,$x=0)
 	{
-		
 		// If there is a query then perform it if not then use cached results..
 		if ( $query )
 		{
 			$this->query($query);
 		}
-		
+
 		// Extract the column values
 		for ( $i=0; $i < count($this->last_result); $i++ )
 		{
 			$new_array[$i] = $this->get_var(null,$x,$i);
 		}
-		
+
 		return $new_array;
 	}
-		
+
 	/**
 	 * Returns the query as a set of results. Default returns OBJECT,
 	 * that is much faster than translating to ARRAY_A or ARRAY_N
@@ -834,16 +813,16 @@ class ezDB_Base
 	public function get_results($query=null, $output = '')
 	{
 		if($output == '') $output = $this->default_type;
-		
+
 		// Log how the function was called
 		$this->func_call = "\$db->get_results(\"$query\", $output)";
-		
+
 		// If there is a query then perform it if not then use cached results..
 		if ( $query )
 		{
 			$this->query($query);
 		}
-				
+
 		// Send back array of objects. Each row is an object
 		if ( $output == OBJECT )
 		{
@@ -857,15 +836,15 @@ class ezDB_Base
 				foreach( $this->last_result as $row )
 				{
 					$new_array[$i] = get_object_vars($row);
-					
+
 					if ( $output == ARRAY_N )
 					{
 						$new_array[$i] = array_values($new_array[$i]);
 					}
-					
+
 					$i++;
 				}
-				
+
 				return $new_array;
 			}
 			else
@@ -877,16 +856,14 @@ class ezDB_Base
 
 	/**
 	 * Return all of the columns
-	 * 
+	 *
 	 * @return array Column information
 	 */
 	public function get_cols()
 	{
-		
 		return $this->col_info;
-
 	}
-		
+
 	/**
 	 * Get metadata regarding a column, about a column in the last query
 	 *
@@ -914,11 +891,10 @@ class ezDB_Base
 				return $this->col_info[$col_offset]->{$info_type};
 			}
 		}
-		
+
 		return false;
 	}
-	
-	
+
 	/**
 	 * Store a results in the cache for a certain query
 	 *
@@ -931,15 +907,15 @@ class ezDB_Base
 	{
 		if($this->cache_query === false || $is_insert)
 			return false;
-			
+
 		$result_cache = array('col_info' => $this->col_info,
-								'last_result' => $this->last_result,
-								'num_rows' => $this->num_rows,
-								'return_value' => $this->num_rows);
-		
+			'last_result' => $this->last_result,
+			'num_rows' => $this->num_rows,
+			'return_value' => $this->num_rows);
+
 		if($this->cache_type == 'memcache')
 		{
-			// @TODO: memcache 
+			// @TODO: memcache
 		}
 		elseif($this->cache_type == 'apc')
 		{
@@ -954,7 +930,7 @@ class ezDB_Base
 				$this->register_error("Could not open cache dir: $this->cache_dir");
 				return false;
 			}
-			
+
 			$ttl = strtotime('+'.$this->cache_timeout.' seconds');
 			$value = $ttl.PHP_EOL.serialize($result_cache);
 
@@ -962,13 +938,11 @@ class ezDB_Base
 			flock($fp);
 			fwrite($fp, $value);
 			fclose($fp);
-
 		}
-		
-		return true;		
+
+		return true;
 	}
-	
-	
+
 	/**
 	 * Get the cached results for a query. This is called more internally
 	 *
@@ -980,11 +954,11 @@ class ezDB_Base
 	{
 		if($this->cache_query === false || $is_insert)
 			return false;
-		
+
 		# Check if we want to us memcache, and whether it's available
 		if($this->cache_type == 'memcache')
 		{
-			// @TODO: memcache 
+			// @TODO: memcache
 		}
 		elseif($this->cache_type == 'apc')
 		{
@@ -995,33 +969,32 @@ class ezDB_Base
 		{
 			// The would be cache file for this query
 			$cache_file = $this->cache_dir.'/'.md5($query);
-			
+
 			// Try to get previously cached version
 			if (file_exists($cache_file) )
 			{
 				$contents = file($cache_file);
-			
+
 				# See if the current time is greater than that cutoff
 				if(time() > $contents[0])
 				{
 					return false;
 				}
-			
+
 				# Then return the unserialized version of the store
 				$result_cache = unserialize($contents[1]);
 			}
-		}	
-		
+		}
+
 		$this->from_cache = true;
 		$this->col_info = $result_cache['col_info'];
 		$this->last_result = $result_cache['last_result'];
 		$this->num_rows = $result_cache['num_rows'];
-		
+
 		$this->trace || $this->debug_all ? $this->debug() : null ;
 		return $result_cache['return_value'];
 	}
-	
-	
+
 	/**
 	 * Show values of any variable type "nicely"
 	 *
@@ -1032,18 +1005,17 @@ class ezDB_Base
 	 */
 	public function vardump($mixed='', $return=false)
 	{
-		
 		// Start outup buffering
 		ob_start();
-		
+
 		echo "<p><table><tr><td bgcolor=ffffff><blockquote><font color=000090>";
 		echo "<pre><font face=arial>";
-		
+
 		if ( ! $this->vardump_called )
 		{
 			echo "<font color=800080><b>ezDB</b> (v".ezDB_VERSION.") <b>Variable Dump..</b></font>\n\n";
 		}
-		
+
 		$var_type = gettype ($mixed);
 		print_r(($mixed?$mixed:"<font color=red>No Value / False</font>"));
 		echo "\n\n<b>Type:</b> " . ucfirst($var_type) . "\n";
@@ -1052,23 +1024,22 @@ class ezDB_Base
 		echo "<b>Last Rows Returned:</b> ".count($this->last_result)."\n";
 		echo "</font></pre></font></blockquote></td></tr></table>".$this->donation();
 		echo "\n<hr size=1 noshade color=dddddd>";
-		
+
 		// Stop output buffering and capture debug HTML
 		$html = ob_get_contents();
 		ob_end_clean();
-		
+
 		// Only echo output if it is turned on
 		if ( $this->debug_echo_is_on || $return == false)
 		{
 			echo $html;
 		}
-		
+
 		$this->vardump_called = true;
-		
+
 		return $html;
-		
 	}
-	
+
 	/**
 	 * Show values of any variable type "nicely"
 	 *
@@ -1081,7 +1052,7 @@ class ezDB_Base
 	{
 		$this->vardump($mixed, $return);
 	}
-		
+
 	/**
 	 *  Displays the last query string that was sent to the database & a
 	 * table listing results (if there were any).
@@ -1093,110 +1064,105 @@ class ezDB_Base
 	 */
 	public function debug($return=false)
 	{
-		
 		// Start outup buffering
 		ob_start();
-		
+
 		echo "<blockquote>";
-		
+
 		// Only show ezDB credits once..
 		if ( ! $this->debug_called )
 		{
 			echo "<font color=800080 face=arial size=2><b>ezDB</b> (v".ezDB_VERSION.") <b>Debug..</b></font><p>\n";
 		}
-		
+
 		if ( $this->error )
 		{
 			echo "<font face=arial size=2 color=000099><b>Last Error --</b> [<font color=000000><b>$this->error ($this->errno)</b></font>]<p>";
 		}
-		
+
 		if ( $this->from_disk_cache )
 		{
 			echo "<font face=arial size=2 color=000099><b>Results retrieved from disk cache</b></font><p>";
 		}
-		
+
 		echo "<font face=arial size=2 color=000099><b>Query</b> [$this->num_queries] <b>--</b> ";
 		echo "[<font color=000000><b>$this->last_query</b></font>]</font><p>";
-		
+
 		echo "<font face=arial size=2 color=000099><b>Query Result..</b></font>";
 		echo "<blockquote>";
-		
+
 		if ( $this->col_info )
 		{
-			
 			// =====================================================
 			// Results top rows
-			
+
 			echo "<table cellpadding=5 cellspacing=1 bgcolor=555555>";
 			echo "<tr bgcolor=eeeeee><td nowrap valign=bottom><font color=555599 face=arial size=2><b>(row)</b></font></td>";
-			
-			
+
 			for ( $i=0; $i < count($this->col_info); $i++ )
 			{
 				echo "<td nowrap align=left valign=top><font size=1 color=555599 face=arial>{$this->col_info[$i]->type} {$this->col_info[$i]->max_length}</font><br><span style='font-family: arial; font-size: 10pt; font-weight: bold;'>{$this->col_info[$i]->name}</span></td>";
 			}
-			
+
 			echo "</tr>";
-			
+
 			// ======================================================
 			// print main results
-			
+
 			if ( $this->last_result )
 			{
-				
+
 				$i=0;
 				foreach ( $this->get_results(null,ARRAY_N) as $one_row )
 				{
 					$i++;
 					echo "<tr bgcolor=ffffff><td bgcolor=eeeeee nowrap align=middle><font size=2 color=555599 face=arial>$i</font></td>";
-					
+
 					foreach ( $one_row as $item )
 					{
 						echo "<td nowrap><font face=arial size=2>$item</font></td>";
 					}
-					
+
 					echo "</tr>";
 				}
-				
+
 			} // if last result
 			else
 			{
 				echo "<tr bgcolor=ffffff><td colspan=".(count($this->col_info)+1)."><font face=arial size=2>No Results</font></td></tr>";
 			}
-			
+
 			echo "</table>";
-			
+
 		} // if col_info
 		else
 		{
 			echo "<font face=arial size=2>No Results</font>";
 		}
-		
+
 		echo "</blockquote></blockquote>".$this->donation()."<hr noshade color=dddddd size=1>";
-		
+
 		// Stop output buffering and capture debug HTML
 		$html = ob_get_contents();
 		ob_end_clean();
-		
+
 		// Only echo output if it is turned on
 		if ( $this->debug_echo_is_on || $return == false )
 		{
 			echo $html;
 		}
-		
+
 		$this->debug_called = true;
-		
+
 		return $html;
-		
 	}
-	
+
 	/**********************************************************************
-	*  Naughty little function to ask for some remuniration!
-	*/
-	
+	 *  Naughty little function to ask for some remuniration!
+	 */
 	public function donation()
 	{
 		return "<font size=1 face=arial color=000000>If ezDB has helped <a href=\"https://www.paypal.com/xclick/business=justin%40justinvincent.com&item_name=ezDB&no_note=1&tax=0\" style=\"color: 0000CC;\">make a donation!?</a> &nbsp;&nbsp;<!--[ go on! you know you want to! ]--></font>";
 	}
-	
+
 }

--- a/ezdb_mysqli.class.php
+++ b/ezdb_mysqli.class.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Copyright (c) 2010 Nabeel Shahzad
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
 
@@ -24,12 +24,12 @@
  * @copyright Copyright (c) 2008-2010, Nabeel Shahzad
  * @link http://github.com/nshahzad/ezdb
  * @license MIT License
- * 
- * 
+ *
+ *
  * Based on ezSQL by Justin Vincent: http://justinvincent.com/docs/ezsql/ez_sql_help.htm
- * 
+ *
  */
- 
+
 /**
   * MySQLi implementation for ezDB
   * By Nabeel Shahzad
@@ -49,29 +49,28 @@ class ezDB_mysqli extends ezDB_Base
 	 * @return bool Connect status
 	 *
 	 */
-	public function __construct($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost')
+	public function __construct($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost', $char_set='utf8')
 	{
 		if($dbname == '') return false;
-		
+
 		parent::__construct();
-		
-		if($this->connect($dbuser, $dbpassword, $dbhost))
+
+		if($this->connect($dbuser, $dbpassword, $dbhost, $char_set))
 		{
 			return $this->select($dbname);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Explicitly close the connection on destruct
 	 */
-	
 	public function __destruct()
 	{
 		$this->close();
 	}
-	
+
 	/**
 	 * Connects to database immediately, unless $dbname is blank
 	 *
@@ -85,8 +84,8 @@ class ezDB_mysqli extends ezDB_Base
 	public function quick_connect($dbuser='', $dbpassword='', $dbname='', $dbhost='localhost')
 	{
 		$this->__construct($dbuser, $dbpassword, $dbname, $dbhost);
-	}	
-	
+	}
+
 	/**
 	 * Connect to MySQL, but not to a database
 	 *
@@ -96,27 +95,34 @@ class ezDB_mysqli extends ezDB_Base
 	 * @return bool Success
 	 *
 	 */
-	public function connect($dbuser='', $dbpassword='', $dbhost='localhost')
+	public function connect($dbuser='', $dbpassword='', $dbhost='localhost', $char_set='utf8')
 	{
 		$this->dbh =  new mysqli($dbhost, $dbuser, $dbpassword);
-		
+
 		if(mysqli_connect_errno() != 0)
 		{
 			if($this->throw_exceptions)
 				throw new ezDB_Error(mysqli_connect_error(), mysqli_connect_errno());
-				
+
 			$this->register_error(mysqli_connect_error(), mysqli_connect_errno());
 			return false;
 		}
 		else
 		{
+			# Change character set.
+			if(!$this->dbh->set_charset($char_set))
+			{
+				throw new ezDB_Error('Error loading character set '.$char_set.': %s\n', $this->dbh->error);
+			}
+			# Set MySQL Version
+			$this->server_version=$this->dbh->server_version;
 			$this->clear_errors();
 			return true;
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Select a MySQL Database
 	 *
@@ -132,22 +138,22 @@ class ezDB_mysqli extends ezDB_Base
 			throw new ezDB_Error('No database name', -1);
 			$this->register_error('No database name specified!');
 		}
-		
+
 		// Must have an active database connection
 		if(!$this->dbh)
 		{
 			if($this->throw_exceptions)
 				throw new ezDB_Error(mysqli_connect_error(), mysqli_connect_errno());
-				
+
 			$this->register_error('Can\'t select database, invalid or inactive connection', -1);
 			return false;
 		}
-		
+
 		if(!$this->dbh->select_db($dbname))
 		{
 			if($this->throw_exceptions)
 				throw new ezDB_Error($this->dbh->error, $this->dbh->errno);
-				
+
 			$this->register_error($this->dbh->error, $this->dbh->errno);
 			return false;
 		}
@@ -156,10 +162,10 @@ class ezDB_mysqli extends ezDB_Base
 			$this->clear_errors();
 			return true;
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Close the database connection
 	 */
@@ -167,7 +173,7 @@ class ezDB_mysqli extends ezDB_Base
 	{
 		return @$this->dbh->close();
 	}
-	
+
 	/**
 	 * Format a mySQL string correctly for safe mySQL insert
 	 *  (no matter if magic quotes are on or not)
@@ -180,7 +186,17 @@ class ezDB_mysqli extends ezDB_Base
 	{
 		return $this->dbh->real_escape_string($str);
 	}
-	
+
+	/**
+	 * Return the ID generated in the last query.
+	 *
+	 * @return unknown
+	 */
+	public function get_insert_id()
+	{
+		return mysqli_insert_id($this->dbh);
+	}
+
 	/**
 	 * Returns the DB specific timestamp function (Oracle: SYSDATE, MySQL: NOW())
 	 *
@@ -191,7 +207,7 @@ class ezDB_mysqli extends ezDB_Base
 	{
 		return 'NOW()';
 	}
-	
+
 	/**
 	 * Run the SQL query, and get the result. Returns false on failure
 	 *  Check $this->error() and $this->errno() functions for any errors
@@ -200,71 +216,71 @@ class ezDB_mysqli extends ezDB_Base
 	 * @param string $query SQL Query
 	 * @return mixed Return values
 	 *
-	 */	
+	 */
 	public function query($query)
 	{
 		// Initialise return
 		$return_val = true;
-		
+
 		// Flush cached values..
 		$this->flush();
-		
+
 		// For reg expressions
 		$query = trim($query);
-		
+
 		// Log how the function was called
 		$this->func_call = "\$db->query(\"$query\")";
-		
+
 		// Keep track of the last query for debug..
 		$this->last_query = $query;
-		
+
 		// Count how many queries there have been
 		$this->num_queries++;
-		
+
 		// Use core file cache function
 		if($cache = $this->get_cache($query))
 		{
 			return $cache;
 		}
-		
+
 		// If there is no existing database connection then try to connect
 		if ( ! $this->dbh )
 		{
 			if($this->throw_exceptions)
 				throw new ezDB_Error($this->dbh->error, $this->dbh->errno);
-				
+
 			$this->register_error('There is no active database connection!');
 			return false;
 		}
-		
+
 		// Perform the query via std mysql_query function..
 		$result = $this->dbh->query($query);
 
 		if($result === false)
 		{
 			if($this->throw_exceptions)
-				throw new ezDB_Error($this->dbh->error, $this->dbh->errno);
-				
+				throw new ezDB_Error($this->dbh->error, $this->dbh->errno, $this->last_query);
+
 			$this->register_error($this->dbh->error, $this->dbh->errno);
 		}
 		else
 		{
 			$this->clear_errors();
 		}
-	
+
 		// Query was an insert, delete, update, replace
 		$is_insert = false;
 		if (preg_match("/^(insert|delete|update|replace)\s+/i",$query))
 		{
 			$this->rows_affected = $this->dbh->affected_rows;
 			$this->num_rows = $this->rows_affected;
-		
+
 			if($this->dbh->insert_id > 0)
 			{
 				$this->insert_id = $this->dbh->insert_id;
 				$is_insert = true;
 			}
-			
+
 			// Return number of rows affected
 			$return_val = $this->rows_affected;
 		}
@@ -274,37 +290,37 @@ class ezDB_mysqli extends ezDB_Base
 			// Take note of column info
 			$num_rows = 0;
 			if($result instanceof MySQLi_Result)
-			{	
+			{
 				$this->col_info = $result->fetch_fields();
-						
+
 				// Store Query Results
 				while($row = $result->fetch_object())
 				{
 					$this->last_result[$num_rows] = $row;
 					$num_rows++;
 				}
-				
+
 				$result->close();
 			}
-			
+
 			// Log number of rows the query returned
 			$this->rows_affected = $num_rows;
 			$this->num_rows = $num_rows;
-			
+
 			// Return number of rows selected
 			$return_val = $this->num_rows;
 		}
-		
+
 		// disk caching of queries
 		$this->store_cache($query,$is_insert);
-		
+
 		// If debug ALL queries
 		$this->trace || $this->debug_all ? $this->debug() : null ;
-		
+
 		return $return_val;
 	}
-	
-	
+
+
 	/* this is mysqli only
 	 * incomplete implementation
 	 *//*
@@ -332,6 +348,6 @@ class ezDB_mysqli extends ezDB_Base
 
 		$stmt->execute();
 
-		
+
 	}*/
 }


### PR DESCRIPTION
Changed line breaks from CRLF to LF in ezdb_base.class.php .
Removed empty spaces, line breaks, and unused methods.
Added ability to pass in a character set on db connection. Throws an error if character set could not be loaded.
Changed default daabase to MySQLi since MySQL is depreciated in PHP 5.5+.
Added get_insert_id() method.
Fixed $last_query not displaying when error is thrown.